### PR TITLE
No More Typing When Command is Run

### DIFF
--- a/src/main/java/com/beanbeanjuice/utility/command/CommandManager.java
+++ b/src/main/java/com/beanbeanjuice/utility/command/CommandManager.java
@@ -100,11 +100,7 @@ public class CommandManager {
             CommandErrorType errorType = usage.getERROR(args, event.getGuild());
 
             if (errorType.equals(CommandErrorType.SUCCESS)) {
-
-                event.getChannel().sendTyping().queue();
-
                 CommandContext ctx = new CommandContext(event, args, prefix);
-
                 command.handle(ctx, args, event.getAuthor(), event);
             } else {
                 event.getChannel().sendMessage(indexMessageEmbed(errorType, usage.getIncorrectIndex(), args)).queue();


### PR DESCRIPTION
The bot no longer sends a typing queue in the text channel when a command is run. This fixes issue #71.